### PR TITLE
fixed date time parsing

### DIFF
--- a/src/main/java/net/jgp/books/spark/ch17/lab100_export/ExportWildfiresApp.java
+++ b/src/main/java/net/jgp/books/spark/ch17/lab100_export/ExportWildfiresApp.java
@@ -19,6 +19,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,7 @@ public class ExportWildfiresApp {
         .load(K.TMP_STORAGE + "/" + K.VIIRS_FILE)
         .withColumn("acq_time_min", expr("acq_time % 100"))
         .withColumn("acq_time_hr", expr("int(acq_time / 100)"))
-        .withColumn("acq_time2", unix_timestamp(col("acq_date")))
+        .withColumn("acq_time2", unix_timestamp(col("acq_date").cast(DataTypes.DateType)))
         .withColumn(
             "acq_time3",
             expr("acq_time2 + acq_time_min * 60 + acq_time_hr * 3600"))
@@ -82,7 +83,7 @@ public class ExportWildfiresApp {
         .load(K.TMP_STORAGE + "/" + K.MODIS_FILE)
         .withColumn("acq_time_min", expr("acq_time % 100"))
         .withColumn("acq_time_hr", expr("int(acq_time / 100)"))
-        .withColumn("acq_time2", unix_timestamp(col("acq_date")))
+        .withColumn("acq_time2", unix_timestamp(col("acq_date").cast(DataTypes.DateType)))
         .withColumn(
             "acq_time3",
             expr("acq_time2 + acq_time_min * 60 + acq_time_hr * 3600"))


### PR DESCRIPTION
Without a cast form string to date `acq_datetime` is computed as `null`.

```
+--------+---------+----------+----+-----+---------+----------------+-------+----------+---+--------+------------+----------+----------+
|latitude|longitude|bright_ti4|scan|track|satellite|confidence_level|version|bright_ti5|frp|daynight|acq_datetime|brightness|bright_t31|
+--------+---------+----------+----+-----+---------+----------------+-------+----------+---+--------+------------+----------+----------+
|32.89268| 35.09072|     305.4|0.52|  0.5|        N|         nominal| 1.0NRT|     293.8|1.1|       N|        null|      null|      null|
|32.66387|  35.3937|     308.3|0.55| 0.51|        N|         nominal| 1.0NRT|     292.7|1.1|       N|        null|      null|      null|
|32.66657| 35.39365|     305.0|0.55| 0.51|        N|         nominal| 1.0NRT|     293.0|1.4|       N|        null|      null|      null|
| 31.9656| 35.24709|     308.8|0.56| 0.51|        N|         nominal| 1.0NRT|     290.2|1.6|       N|        null|      null|      null|
```